### PR TITLE
Fixed 'end' keyword miss use.

### DIFF
--- a/Matlab/method.sublime-completions
+++ b/Matlab/method.sublime-completions
@@ -861,7 +861,7 @@
 		{"trigger": "empty\tMatlab method", "contents": "empty(${1:args})"} ,
 		{"trigger": "enableNETfromNetworkDrive\tMatlab method", "contents": "enableNETfromNetworkDrive(${1:args})"} ,
 		{"trigger": "enableservice\tMatlab method", "contents": "enableservice(${1:args})"} ,
-		{"trigger": "end\tMatlab method", "contents": "end(${1:args})"} ,
+		{"trigger": "end\tMatlab method", "contents": "end"} ,
 		{"trigger": "eomday\tMatlab method", "contents": "eomday(${1:args})"} ,
 		{"trigger": "eps\tMatlab method", "contents": "eps(${1:args})"} ,
 		{"trigger": "eq\tMatlab method", "contents": "eq(${1:args})"} ,


### PR DESCRIPTION
Fixed 'end' keyword miss use. 

See http://www.mathworks.com/help/matlab/ref/end.html?searchHighlight=end for the correct reference.
